### PR TITLE
Check project status when refunding pools

### DIFF
--- a/packages/contracts/contracts/discovery/Batch.sol
+++ b/packages/contracts/contracts/discovery/Batch.sol
@@ -3,14 +3,13 @@ pragma solidity =0.8.12;
 
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
-import {ICommon} from "./interfaces/ICommon.sol";
 import {IProject} from "./interfaces/IProject.sol";
 import {IController} from "./interfaces/IController.sol";
 import {IBatch} from "./interfaces/IBatch.sol";
 import {IStaking} from "./interfaces/IStaking.sol";
 import {ProjectVoting} from "./ProjectVoting.sol";
 
-contract Batch is IBatch, ICommon, ProjectVoting {
+contract Batch is IBatch, ProjectVoting {
     using ERC165Checker for address;
 
     /// List of addresses for the project in the batch
@@ -120,12 +119,6 @@ contract Batch is IBatch, ICommon, ProjectVoting {
         return 0;
     }
 
-    function inInvestmentPeriod() external returns (bool) {
-        return
-            votingPeriod.start >= block.timestamp &&
-            investmentEnd <= block.timestamp;
-    }
-
     function projectVoting_voteLimitPerUser()
         public
         view
@@ -133,6 +126,16 @@ contract Batch is IBatch, ICommon, ProjectVoting {
         returns (uint256)
     {
         return slotCount;
+    }
+
+    //
+    // IBatch
+    //
+
+    function inInvestmentPeriod() external view returns (bool) {
+        return
+            votingPeriod.start >= block.timestamp &&
+            investmentEnd <= block.timestamp;
     }
 
     function hasVotedForProject(address _user, address _project)

--- a/packages/contracts/contracts/discovery/Controller.sol
+++ b/packages/contracts/contracts/discovery/Controller.sol
@@ -112,6 +112,7 @@ contract Controller is IController, ERC165, AccessControl {
             );
 
             projectsToBatches[project] = address(batch);
+            IProject(project).setBatch(address(batch));
         }
 
         emit BatchCreated(address(batch));

--- a/packages/contracts/contracts/discovery/Project.sol
+++ b/packages/contracts/contracts/discovery/Project.sol
@@ -6,6 +6,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import {IController} from "./interfaces/IController.sol";
 import {IProject} from "./interfaces/IProject.sol";
+import {IPool} from "./interfaces/IPool.sol";
 
 import {StakersPool} from "./pools/StakersPool.sol";
 import {PeoplesPool} from "./pools/PeoplesPool.sol";
@@ -52,6 +53,8 @@ contract Project is IProject, ERC165 {
     // has the project been approved by the legal team
     bool public override(IProject) approvedByLegal;
 
+    address public batch;
+
     constructor(
         string memory _description,
         address _token,
@@ -94,6 +97,11 @@ contract Project is IProject, ERC165 {
             IController(controller).hasLegalManagerRole(msg.sender),
             "not a legal manager"
         );
+        _;
+    }
+
+    modifier onlyController(address _account) {
+        require(_account == controller, "not the controller");
         _;
     }
 
@@ -158,6 +166,12 @@ contract Project is IProject, ERC165 {
         returns (uint256)
     {
         return (_amount * rate) / MUL;
+    }
+
+    function setBatch(address _batch) external onlyController(msg.sender) {
+        batch = _batch;
+        IPool(stakersPool).setBatch(_batch);
+        IPool(peoplesPool).setBatch(_batch);
     }
 
     //

--- a/packages/contracts/contracts/discovery/ProjectVoting.sol
+++ b/packages/contracts/contracts/discovery/ProjectVoting.sol
@@ -7,12 +7,6 @@ import {Math} from "../libraries/Math.sol";
 import "hardhat/console.sol";
 
 abstract contract ProjectVoting is ICommon {
-    enum ProjectStatus {
-        InProgress,
-        Won,
-        Lost
-    }
-
     struct SortableVote {
         uint256 originalIndex;
         uint256 count;

--- a/packages/contracts/contracts/discovery/interfaces/IBatch.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IBatch.sol
@@ -1,6 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity =0.8.12;
 
-interface IBatch {
+import {ICommon} from "./ICommon.sol";
+
+interface IBatch is ICommon {
     function vote(address projectAddress) external;
+
+    function inInvestmentPeriod() external view returns (bool);
+
+    function hasVotedForProject(address _user, address _project)
+        external
+        view
+        returns (bool);
+
+    function setVotingPeriod(
+        uint256 start,
+        uint256 end,
+        uint256 extraInvestmentDuration
+    ) external;
+
+    function getCurrentWinners() external view returns (address[] memory);
+
+    function getProjectStatus(address projectAddress)
+        external
+        view
+        returns (ProjectStatus);
 }

--- a/packages/contracts/contracts/discovery/interfaces/ICommon.sol
+++ b/packages/contracts/contracts/discovery/interfaces/ICommon.sol
@@ -7,4 +7,10 @@ interface ICommon {
         uint256 start;
         uint256 end;
     }
+
+    enum ProjectStatus {
+        InProgress,
+        Won,
+        Lost
+    }
 }

--- a/packages/contracts/contracts/discovery/interfaces/IPool.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IPool.sol
@@ -38,4 +38,6 @@ interface IPool {
 
     /// Similar to Sale.allocation
     function allocation(address _to) external view returns (uint256);
+
+    function setBatch(address _batch) external;
 }

--- a/packages/contracts/contracts/discovery/interfaces/IProject.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IProject.sol
@@ -36,4 +36,6 @@ interface IProject {
         external
         view
         returns (uint256);
+
+    function setBatch(address _batch) external;
 }

--- a/packages/contracts/contracts/test/MockBatch.sol
+++ b/packages/contracts/contracts/test/MockBatch.sol
@@ -56,7 +56,7 @@ contract MockBatch is IBatch {
         return projectsStatus[projectAddress];
     }
 
-    function test_setProjectStatus(address projectAddress, uint256 status)
+    function mock_setProjectStatus(address projectAddress, uint256 status)
         external
     {
         projectsStatus[projectAddress] = ProjectStatus(status);

--- a/packages/contracts/contracts/test/MockBatch.sol
+++ b/packages/contracts/contracts/test/MockBatch.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.12;
+
+import {IBatch} from "../discovery/interfaces/IBatch.sol";
+
+import "hardhat/console.sol";
+
+contract MockBatch is IBatch {
+    mapping(address => ProjectStatus) projectsStatus;
+
+    function vote(address projectAddress) external override(IBatch) {
+        revert();
+    }
+
+    function inInvestmentPeriod()
+        external
+        view
+        override(IBatch)
+        returns (bool)
+    {
+        return true;
+    }
+
+    function hasVotedForProject(address _user, address _project)
+        external
+        view
+        override(IBatch)
+        returns (bool)
+    {
+        return false;
+    }
+
+    function setVotingPeriod(
+        uint256 start,
+        uint256 end,
+        uint256 extraInvestmentDuration
+    ) external override(IBatch) {
+        revert();
+    }
+
+    function getCurrentWinners()
+        external
+        view
+        override(IBatch)
+        returns (address[] memory)
+    {
+        revert();
+    }
+
+    function getProjectStatus(address projectAddress)
+        external
+        view
+        override(IBatch)
+        returns (ProjectStatus)
+    {
+        return projectsStatus[projectAddress];
+    }
+
+    function test_setProjectStatus(address projectAddress, uint256 status)
+        external
+    {
+        projectsStatus[projectAddress] = ProjectStatus(status);
+    }
+}

--- a/packages/contracts/contracts/test/MockProject.sol
+++ b/packages/contracts/contracts/test/MockProject.sol
@@ -5,14 +5,14 @@ import {IProject} from "../discovery/interfaces/IProject.sol";
 import {IPool} from "../discovery/interfaces/IPool.sol";
 import {TestPool} from "../discovery/pools/TestPool.sol";
 
-import "hardhat/console.sol";
-
 contract MockProject is IProject {
     /// @inheritdoc IProject
     address public override(IProject) stakersPool;
 
     /// @inheritdoc IProject
     address public override(IProject) peoplesPool;
+
+    address public batch;
 
     /// Approval function from an eligible project manager
     function approveByManager() external {
@@ -83,5 +83,10 @@ contract MockProject is IProject {
         external
     {
         peoplesPool = address(new TestPool(_supply, _investmentToken));
+    }
+
+    function setBatch(address _batch) external {
+        batch = _batch;
+        IPool(stakersPool).setBatch(_batch);
     }
 }

--- a/packages/contracts/test/contracts/discovery/Batch.ts
+++ b/packages/contracts/test/contracts/discovery/Batch.ts
@@ -99,6 +99,8 @@ describe("Batch", () => {
       expect(await batch.projects(0)).to.eq(fakeProject.address);
       expect(await batch.projects(1)).to.eq(anotherFakeProject.address);
       expect(await batch.slotCount()).to.eq(2);
+      expect(await fakeProject.batch()).to.eq(batch.address);
+      expect(await anotherFakeProject.batch()).to.eq(batch.address);
     });
 
     it("fails with an empty list of projects", async () => {
@@ -125,10 +127,17 @@ describe("Batch", () => {
       ).to.be.revertedWith("project must be an IProject");
     });
 
-    xit("fails if one of the projects is not whitelisted", async () => {
+    it("fails if one of the projects is not ready", async () => {
+      fakeProject = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD
+      );
+
       await expect(
-        setUpBatch(controller, [fakeProject], owner)
-      ).to.be.revertedWith("project must be whitelisted");
+        controller.createBatch([fakeProject.address], 1)
+      ).to.be.revertedWith("project not ready");
     });
   });
 

--- a/packages/contracts/test/contracts/discovery/pool/Pool.ts
+++ b/packages/contracts/test/contracts/discovery/pool/Pool.ts
@@ -152,7 +152,7 @@ describe("Pool", () => {
 
     it("is the full amount if the project has lost", async () => {
       await project.connect(alice).invest(0, 200);
-      await batch.test_setProjectStatus(project.address, 2);
+      await batch.mock_setProjectStatus(project.address, 2);
 
       expect(await pool.refundableAmount(alice.address)).to.equal(200);
     });


### PR DESCRIPTION
Why:

* If the project looses there is no rising tide to be ran, all of the
  funds should be immediately available for refund.

This change addresses the need by:

* Passing the batch address along to the project and respective pools as
  soon as we have it. The reason we are doing this is to minimize the
  amount of hops when making checks. The pools can talk directly to the
  batch.

  Moving the ProjectStatus enum to the ICommon interface, so that it is
  available everywhere.