### PR TITLE
Allow project tokens to be withdrawn with vesting

### DIFF
--- a/packages/contracts/contracts/discovery/Batch.sol
+++ b/packages/contracts/contracts/discovery/Batch.sol
@@ -120,7 +120,7 @@ contract Batch is IBatch, ICommon, ProjectVoting {
         return 0;
     }
 
-    function inInvestmentPeriod() external returns (bool) {
+    function inInvestmentPeriod() external view returns (bool) {
         return
             votingPeriod.start >= block.timestamp &&
             investmentEnd <= block.timestamp;

--- a/packages/contracts/contracts/discovery/Controller.sol
+++ b/packages/contracts/contracts/discovery/Controller.sol
@@ -78,14 +78,18 @@ contract Controller is IController, ERC165, AccessControl {
         address _token,
         uint256 _saleSupply,
         uint256 _rate,
-        address _investmentToken
+        address _investmentToken,
+        uint256 _cliffMonths,
+        uint256 _vestingMonths
     ) external override(IController) {
         IProject project = new Project(
             _description,
             _token,
             _saleSupply,
             _rate,
-            _investmentToken
+            _investmentToken,
+            _cliffMonths,
+            _vestingMonths
         );
 
         emit ProjectRegistered(address(project));

--- a/packages/contracts/contracts/discovery/Project.sol
+++ b/packages/contracts/contracts/discovery/Project.sol
@@ -57,7 +57,9 @@ contract Project is IProject, ERC165 {
         address _token,
         uint256 _saleSupply,
         uint256 _rate,
-        address _investmentToken
+        address _investmentToken,
+        uint256 _cliffMonths,
+        uint256 _vestingMonths
     ) {
         controller = msg.sender;
 
@@ -70,10 +72,20 @@ contract Project is IProject, ERC165 {
         uint256 peoplesPoolSupply = saleSupply - stakersPoolSupply;
 
         stakersPool = address(
-            new StakersPool(stakersPoolSupply, _investmentToken)
+            new StakersPool(
+                stakersPoolSupply,
+                _investmentToken,
+                _cliffMonths,
+                _vestingMonths
+            )
         );
         peoplesPool = address(
-            new PeoplesPool(peoplesPoolSupply, _investmentToken)
+            new PeoplesPool(
+                peoplesPoolSupply,
+                _investmentToken,
+                _cliffMonths,
+                _vestingMonths
+            )
         );
     }
 

--- a/packages/contracts/contracts/discovery/interfaces/IController.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IController.sol
@@ -42,7 +42,9 @@ interface IController {
         address _token,
         uint256 _saleSupply,
         uint256 _rate,
-        address _investmentToken
+        address _investmentToken,
+        uint256 _cliffMonths,
+        uint256 _vestingMonths
     ) external;
 
     /// Checks if a project is included in the given batch

--- a/packages/contracts/contracts/discovery/interfaces/IPool.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IPool.sol
@@ -30,6 +30,29 @@ interface IPool {
      */
     function refundableAmount(address _to) external view returns (uint256);
 
+    /**
+     * Withdraws currently withdrawable amount for the
+     * given address
+     *
+     * @param to Address to withdraw to
+     */
+    function withdraw(address to) external;
+
+    /**
+     * Calculates withdrawable amount of tokens for an address.
+     * This should take into account:
+     *   - total vested amount
+     *   - already withdrawn amount
+     *   - number of months elapsed since the end of the account's cliff period
+     *   - total number of months this account is vesting for
+     * Vesting should be linear once cliff ends, but in monthly ticks, instead
+     * of a continuous release
+     *
+     * @param to The address to query
+     * @return The currently withdrawable amount
+     */
+    function withdrawable(address to) external view returns (uint256);
+
     /// Similar to Sale.uncappedAllocation
     function uncappedAllocation(address _to)
         external

--- a/packages/contracts/contracts/discovery/interfaces/IPool.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IPool.sol
@@ -31,14 +31,6 @@ interface IPool {
     function refundableAmount(address _to) external view returns (uint256);
 
     /**
-     * Withdraws currently withdrawable amount for the
-     * given address
-     *
-     * @param to Address to withdraw to
-     */
-    function withdraw(address to) external;
-
-    /**
      * Calculates withdrawable amount of tokens for an address.
      * This should take into account:
      *   - total vested amount
@@ -61,4 +53,6 @@ interface IPool {
 
     /// Similar to Sale.allocation
     function allocation(address _to) external view returns (uint256);
+
+    function withdrawn(address _to) external view returns (uint256);
 }

--- a/packages/contracts/contracts/discovery/interfaces/IProject.sol
+++ b/packages/contracts/contracts/discovery/interfaces/IProject.sol
@@ -25,6 +25,12 @@ interface IProject {
 
     function peoplesPool() external view returns (address);
 
+    function token() external view returns (address);
+
+    function withdrawnPeoplesPool(address to) external view returns (uint256);
+
+    function withdrawnStakersPool(address to) external view returns (uint256);
+
     function invest(uint256 _peoplesAmount, uint256 _stakersAmount) external;
 
     function investmentTokenToToken(uint256 _amount)
@@ -36,4 +42,12 @@ interface IProject {
         external
         view
         returns (uint256);
+
+    /**
+     * Withdraws currently withdrawable amount for the
+     * given address on both pools
+     *
+     * @param to Address to withdraw to
+     */
+    function withdraw(address to) external;
 }

--- a/packages/contracts/contracts/discovery/pools/PeoplesPool.sol
+++ b/packages/contracts/contracts/discovery/pools/PeoplesPool.sol
@@ -4,7 +4,10 @@ pragma solidity =0.8.12;
 import {Pool} from "./Pool.sol";
 
 contract PeoplesPool is Pool {
-    constructor(uint256 _saleSupply, address _investmentToken)
-        Pool(_saleSupply, _investmentToken)
-    {}
+    constructor(
+        uint256 _saleSupply,
+        address _investmentToken,
+        uint256 _cliffMonths,
+        uint256 _vestingMonths
+    ) Pool(_saleSupply, _investmentToken, _cliffMonths, _vestingMonths) {}
 }

--- a/packages/contracts/contracts/discovery/pools/PeoplesPool.sol
+++ b/packages/contracts/contracts/discovery/pools/PeoplesPool.sol
@@ -2,6 +2,7 @@
 pragma solidity =0.8.12;
 
 import {Pool} from "./Pool.sol";
+import {IProject} from "../interfaces/IProject.sol";
 
 contract PeoplesPool is Pool {
     constructor(
@@ -10,4 +11,13 @@ contract PeoplesPool is Pool {
         uint256 _cliffMonths,
         uint256 _vestingMonths
     ) Pool(_saleSupply, _investmentToken, _cliffMonths, _vestingMonths) {}
+
+    function withdrawn(address _to)
+        public
+        view
+        override(Pool)
+        returns (uint256)
+    {
+        return IProject(project).withdrawnPeoplesPool(_to);
+    }
 }

--- a/packages/contracts/contracts/discovery/pools/Pool.sol
+++ b/packages/contracts/contracts/discovery/pools/Pool.sol
@@ -57,7 +57,6 @@ abstract contract Pool is IPool, RisingTide {
     // Total supply of the project's token up for sale
     uint256 public immutable saleSupply;
 
-    mapping(address => uint256) public withdrawn;
     uint256 public cliffMonths;
     uint256 public vestingMonths;
     uint256 public vestingStart;
@@ -151,15 +150,23 @@ abstract contract Pool is IPool, RisingTide {
         return IProject(project).tokenToInvestmentToken(uncapped - capped);
     }
 
-    function withdraw(address to) external override(IPool) {}
+    function withdrawn(address _to)
+        public
+        view
+        virtual
+        override(IPool)
+        returns (uint256)
+    {
+        revert("not implemented");
+    }
 
     function withdrawable(address to)
-        external
+        public
         view
         override(IPool)
         returns (uint256)
     {
-        uint256 localWithrawn = withdrawn[to];
+        uint256 localWithdrawn = withdrawn(to);
         uint256 total = allocation(to);
         uint256 elapsed = _numberOfPeriodsElapsed();
         uint256 cliff = cliffMonths;
@@ -174,11 +181,11 @@ abstract contract Pool is IPool, RisingTide {
         }
 
         if (elapsed >= vesting + cliff) {
-            return total - localWithrawn;
+            return total - localWithdrawn;
         }
 
         uint256 perMonth = total / vesting;
-        return (perMonth * (elapsed - cliff)) - localWithrawn;
+        return (perMonth * (elapsed - cliff)) - localWithdrawn;
     }
 
     /// @inheritdoc IPool

--- a/packages/contracts/contracts/discovery/pools/StakersPool.sol
+++ b/packages/contracts/contracts/discovery/pools/StakersPool.sol
@@ -4,7 +4,10 @@ pragma solidity =0.8.12;
 import {Pool} from "./Pool.sol";
 
 contract StakersPool is Pool {
-    constructor(uint256 _saleSupply, address _investmentToken)
-        Pool(_saleSupply, _investmentToken)
-    {}
+    constructor(
+        uint256 _saleSupply,
+        address _investmentToken,
+        uint256 _cliffMonths,
+        uint256 _vestingMonths
+    ) Pool(_saleSupply, _investmentToken, _cliffMonths, _vestingMonths) {}
 }

--- a/packages/contracts/contracts/discovery/pools/StakersPool.sol
+++ b/packages/contracts/contracts/discovery/pools/StakersPool.sol
@@ -2,6 +2,7 @@
 pragma solidity =0.8.12;
 
 import {Pool} from "./Pool.sol";
+import {IProject} from "../interfaces/IProject.sol";
 
 contract StakersPool is Pool {
     constructor(
@@ -10,4 +11,13 @@ contract StakersPool is Pool {
         uint256 _cliffMonths,
         uint256 _vestingMonths
     ) Pool(_saleSupply, _investmentToken, _cliffMonths, _vestingMonths) {}
+
+    function withdrawn(address _to)
+        public
+        view
+        override(Pool)
+        returns (uint256)
+    {
+        return IProject(project).withdrawnStakersPool(_to);
+    }
 }

--- a/packages/contracts/contracts/discovery/pools/TestPool.sol
+++ b/packages/contracts/contracts/discovery/pools/TestPool.sol
@@ -4,7 +4,14 @@ pragma solidity =0.8.12;
 import {Pool} from "./Pool.sol";
 
 contract TestPool is Pool {
-    constructor(uint256 _saleSupply, address _investmentToken)
-        Pool(_saleSupply, _investmentToken)
-    {}
+    constructor(
+        uint256 _saleSupply,
+        address _investmentToken,
+        uint256 _cliffMonths,
+        uint256 _vestingMonths
+    ) Pool(_saleSupply, _investmentToken, _cliffMonths, _vestingMonths) {}
+
+    function mock_setVestingStart(uint256 _vestingStart) public {
+        vestingStart = _vestingStart;
+    }
 }

--- a/packages/contracts/contracts/discovery/pools/TestPool.sol
+++ b/packages/contracts/contracts/discovery/pools/TestPool.sol
@@ -2,6 +2,9 @@
 pragma solidity =0.8.12;
 
 import {Pool} from "./Pool.sol";
+import {IProject} from "../interfaces/IProject.sol";
+
+import "hardhat/console.sol";
 
 contract TestPool is Pool {
     constructor(
@@ -13,5 +16,14 @@ contract TestPool is Pool {
 
     function mock_setVestingStart(uint256 _vestingStart) public {
         vestingStart = _vestingStart;
+    }
+
+    function withdrawn(address _to)
+        public
+        view
+        override(Pool)
+        returns (uint256)
+    {
+        return IProject(project).withdrawnStakersPool(_to);
     }
 }

--- a/packages/contracts/contracts/test/MockProject.sol
+++ b/packages/contracts/contracts/test/MockProject.sol
@@ -15,7 +15,7 @@ contract MockProject is IProject {
     address public override(IProject) peoplesPool;
 
     /// Approval function from an eligible project manager
-    function approveByManager() external {
+    function approveByManager() external pure {
         revert("not implemented");
     }
 
@@ -25,7 +25,7 @@ contract MockProject is IProject {
     }
 
     /// Approval function from the legal team
-    function approveByLegal() external {
+    function approveByLegal() external pure {
         revert("not implemented");
     }
 
@@ -57,7 +57,7 @@ contract MockProject is IProject {
 
     function investmentTokenToToken(uint256 _amount)
         external
-        view
+        pure
         override(IProject)
         returns (uint256)
     {
@@ -73,15 +73,35 @@ contract MockProject is IProject {
         return _amount;
     }
 
-    function test_createStakersPool(uint256 _supply, address _investmentToken)
-        external
-    {
-        stakersPool = address(new TestPool(_supply, _investmentToken));
+    function test_createStakersPool(
+        uint256 _supply,
+        address _investmentToken,
+        uint256 _cliffMonths,
+        uint256 _vestingMonths
+    ) external {
+        stakersPool = address(
+            new TestPool(
+                _supply,
+                _investmentToken,
+                _cliffMonths,
+                _vestingMonths
+            )
+        );
     }
 
-    function test_createPeoplesPool(uint256 _supply, address _investmentToken)
-        external
-    {
-        peoplesPool = address(new TestPool(_supply, _investmentToken));
+    function test_createPeoplesPool(
+        uint256 _supply,
+        address _investmentToken,
+        uint256 _cliffMonths,
+        uint256 _vestingMonths
+    ) external {
+        peoplesPool = address(
+            new TestPool(
+                _supply,
+                _investmentToken,
+                _cliffMonths,
+                _vestingMonths
+            )
+        );
     }
 }

--- a/packages/contracts/src/deployConfigs.ts
+++ b/packages/contracts/src/deployConfigs.ts
@@ -1,7 +1,6 @@
 import { network, ethers } from "hardhat";
 import type { BigNumber } from "ethers";
 
-console.log(Math.floor(new Date(2022, 4, 12, 8, 30).getTime() / 1000));
 const MANDALA_REGISTRY_ROOT = "0xC3e923e0CE5125088cDa62935056d6B5F14F234c";
 
 interface CTNDSale {

--- a/packages/contracts/test/contracts/discovery/Controller.ts
+++ b/packages/contracts/test/contracts/discovery/Controller.ts
@@ -77,7 +77,14 @@ describe("Controller", () => {
       await citizend.transfer(alice.address, 1000);
       await citizend.connect(alice).approve(staking.address, MaxUint256);
       await staking.connect(alice).stake(100);
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be.true;
     });
@@ -86,7 +93,14 @@ describe("Controller", () => {
       await citizend.transfer(alice.address, 1000);
       await citizend.connect(alice).approve(staking.address, MaxUint256);
       await staking.connect(alice).stake(100);
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be
         .false;
@@ -94,7 +108,14 @@ describe("Controller", () => {
 
     it("is false if the user does not belong to the DAO", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be
         .false;
@@ -103,7 +124,14 @@ describe("Controller", () => {
     it("is false if the user does not have staked tokens", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
       await citizend.transfer(alice.address, 1000);
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be
         .false;
@@ -114,7 +142,14 @@ describe("Controller", () => {
     it("is true if the user meets all the requirements", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
       await citizend.transfer(alice.address, 1000);
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
       await makeProjectReady(project, projectToken);
       const batch: Batch = await setUpBatch(controller, [project], owner);
       await batch.connect(alice).vote(project.address);
@@ -126,7 +161,14 @@ describe("Controller", () => {
 
     it("is false if the user does not have the KYC", async () => {
       await citizend.transfer(alice.address, 1000);
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
       await makeProjectReady(project, projectToken);
       const batch: Batch = await setUpBatch(controller, [project], owner);
 
@@ -137,7 +179,14 @@ describe("Controller", () => {
 
     it("is false if the user does not belong to the DAO", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
       await makeProjectReady(project, projectToken);
       const batch: Batch = await setUpBatch(controller, [project], owner);
 
@@ -149,7 +198,14 @@ describe("Controller", () => {
     it("is false if the user hasn't voted in the project", async () => {
       await citizend.transfer(alice.address, 1000);
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
       await makeProjectReady(project, projectToken);
       await setUpBatch(controller, [project], owner);
 
@@ -161,7 +217,14 @@ describe("Controller", () => {
 
   describe("registerProject", () => {
     it("registers a project", async () => {
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
 
       expect(await project.description()).to.eq("My Project");
       expect(await project.token()).to.eq(projectToken.address);
@@ -176,7 +239,9 @@ describe("Controller", () => {
           projectToken.address,
           parseUnits("1000"),
           parseUnits("2"),
-          aUSD.address
+          aUSD.address,
+          0,
+          3
         )
       ).to.emit(controller, "ProjectRegistered");
     });
@@ -188,7 +253,14 @@ describe("Controller", () => {
 
   describe("createBatch", () => {
     it("creates a batch", async () => {
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
       await makeProjectReady(project, projectToken);
 
       expect(await project.approvedByLegal()).to.equal(true);
@@ -200,7 +272,14 @@ describe("Controller", () => {
     });
 
     it("reverts if a project is not approved", async () => {
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
 
       await expect(
         controller.createBatch([project.address], 1)
@@ -208,7 +287,14 @@ describe("Controller", () => {
     });
 
     it("reverts if a project is already included in a different batch", async () => {
-      project = await registerProject(owner, projectToken, controller, aUSD);
+      project = await registerProject(
+        owner,
+        projectToken,
+        controller,
+        aUSD,
+        0,
+        3
+      );
       await makeProjectReady(project, projectToken);
 
       expect(await project.approvedByLegal()).to.equal(true);

--- a/packages/contracts/test/contracts/discovery/Controller.ts
+++ b/packages/contracts/test/contracts/discovery/Controller.ts
@@ -77,14 +77,7 @@ describe("Controller", () => {
       await citizend.transfer(alice.address, 1000);
       await citizend.connect(alice).approve(staking.address, MaxUint256);
       await staking.connect(alice).stake(100);
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be.true;
     });
@@ -93,14 +86,7 @@ describe("Controller", () => {
       await citizend.transfer(alice.address, 1000);
       await citizend.connect(alice).approve(staking.address, MaxUint256);
       await staking.connect(alice).stake(100);
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be
         .false;
@@ -108,14 +94,7 @@ describe("Controller", () => {
 
     it("is false if the user does not belong to the DAO", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be
         .false;
@@ -124,14 +103,7 @@ describe("Controller", () => {
     it("is false if the user does not have staked tokens", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
       await citizend.transfer(alice.address, 1000);
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
 
       expect(await controller.canInvestInStakersPool(alice.address)).to.be
         .false;
@@ -142,14 +114,7 @@ describe("Controller", () => {
     it("is true if the user meets all the requirements", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
       await citizend.transfer(alice.address, 1000);
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
       await makeProjectReady(project, projectToken);
       const batch: Batch = await setUpBatch(controller, [project], owner);
       await batch.connect(alice).vote(project.address);
@@ -161,14 +126,7 @@ describe("Controller", () => {
 
     it("is false if the user does not have the KYC", async () => {
       await citizend.transfer(alice.address, 1000);
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
       await makeProjectReady(project, projectToken);
       const batch: Batch = await setUpBatch(controller, [project], owner);
 
@@ -179,14 +137,7 @@ describe("Controller", () => {
 
     it("is false if the user does not belong to the DAO", async () => {
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
       await makeProjectReady(project, projectToken);
       const batch: Batch = await setUpBatch(controller, [project], owner);
 
@@ -198,14 +149,7 @@ describe("Controller", () => {
     it("is false if the user hasn't voted in the project", async () => {
       await citizend.transfer(alice.address, 1000);
       await registry.addUserAddress(alice.address, formatBytes32String("id1"));
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
       await makeProjectReady(project, projectToken);
       await setUpBatch(controller, [project], owner);
 
@@ -217,14 +161,7 @@ describe("Controller", () => {
 
   describe("registerProject", () => {
     it("registers a project", async () => {
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
 
       expect(await project.description()).to.eq("My Project");
       expect(await project.token()).to.eq(projectToken.address);
@@ -253,14 +190,7 @@ describe("Controller", () => {
 
   describe("createBatch", () => {
     it("creates a batch", async () => {
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
       await makeProjectReady(project, projectToken);
 
       expect(await project.approvedByLegal()).to.equal(true);
@@ -272,14 +202,7 @@ describe("Controller", () => {
     });
 
     it("reverts if a project is not approved", async () => {
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
 
       await expect(
         controller.createBatch([project.address], 1)
@@ -287,14 +210,7 @@ describe("Controller", () => {
     });
 
     it("reverts if a project is already included in a different batch", async () => {
-      project = await registerProject(
-        owner,
-        projectToken,
-        controller,
-        aUSD,
-        0,
-        3
-      );
+      project = await registerProject(owner, projectToken, controller, aUSD);
       await makeProjectReady(project, projectToken);
 
       expect(await project.approvedByLegal()).to.equal(true);

--- a/packages/contracts/test/contracts/discovery/ProjectVoting.ts
+++ b/packages/contracts/test/contracts/discovery/ProjectVoting.ts
@@ -256,7 +256,9 @@ describe("ProjectVoting", () => {
       fakeToken.address,
       1000,
       10,
-      aUSD.address
+      aUSD.address,
+      0,
+      3
     );
   }
 });

--- a/packages/contracts/test/contracts/discovery/helpers.ts
+++ b/packages/contracts/test/contracts/discovery/helpers.ts
@@ -26,7 +26,9 @@ export async function registerProject(
     projectToken.address,
     parseUnits("1000"),
     parseUnits("2"),
-    investmentToken.address
+    investmentToken.address,
+    0,
+    3
   );
 
   const event = await findEvent(tx, "ProjectRegistered");


### PR DESCRIPTION
Why:

* Tokens that investors will get from the projects will also be subject
  to vesting. How many months of vesting and/or cliff can be
  configurable per project.
* Once a project has won, investors need to get their tokens, taking
  into account the vesting period

This change addresses the need by:

* Adding a withrawable function that takes into account how much an
  investor is able to get at a given time. The start time of the vesting
  is work in progress and will depend on information we will get from
  the batch.
* Adding the withdraw function to the project, which consults both pool
  to see how much an investor has invested already. This allows the
  investor to withdraw everything in on transaction.