### PR TITLE
Update allocation function

### DIFF
--- a/packages/contracts/test/contracts/token/Sale.d.sol
+++ b/packages/contracts/test/contracts/token/Sale.d.sol
@@ -431,7 +431,8 @@ contract SaleTest is Test {
         require(sale.allocation(alice) == 5 ether);
         require(
             sale.allocation(alice) ==
-                (sale.tokenToPaymentToken(6 ether) / sale.currentTokenPrice()) * 1 ether
+                (sale.tokenToPaymentToken(6 ether) / sale.currentTokenPrice()) *
+                    1 ether
         );
     }
 

--- a/packages/contracts/test/contracts/token/Sale.d.sol
+++ b/packages/contracts/test/contracts/token/Sale.d.sol
@@ -425,8 +425,6 @@ contract SaleTest is Test {
 
         vm.warp(sale.end() + 1000);
 
-        console.log(sale.allocation(alice));
-
         require(sale.currentTokenPrice() == 0.24 ether);
         require(sale.allocation(alice) == 5 ether);
         require(


### PR DESCRIPTION
Why:
* The `allocation` function in the Sale contract needs to take into
  consideration the sale not reaching the maximum target. In that
  scenario, Rising Tide does not trigger and we follow a curve to
  calculate the token price based in the total amount commited

How:
* Adding a function that calculates the current token price based on the
  amount contributed
* Adding `minPrice` and `maxPrice` to limit the price of the token
* Updating the `allocation` function to consider the below max target
  case