### PR TITLE
Add APPSIGNAL env

### DIFF
--- a/packages/web-app/appsignal.cjs
+++ b/packages/web-app/appsignal.cjs
@@ -3,7 +3,7 @@ const { Appsignal } = require('@appsignal/nodejs');
 new Appsignal({
   active: true,
   name: 'citizend',
-  environment: process.env.NEXT_APP_SIGNAL_ENV,
+  environment: process.env.NEXT_APP_SIGNAL_ENV || process.env.NODE_ENV,
   pushApiKey: process.env.NEXT_APP_SIGNAL,
   disableDefaultInstrumentations: ['@opentelemetry/instrumentation-http'],
 });

--- a/packages/web-app/appsignal.cjs
+++ b/packages/web-app/appsignal.cjs
@@ -3,6 +3,7 @@ const { Appsignal } = require('@appsignal/nodejs');
 new Appsignal({
   active: true,
   name: 'citizend',
+  environment: process.env.NEXT_APP_SIGNAL_ENV,
   pushApiKey: process.env.NEXT_APP_SIGNAL,
   disableDefaultInstrumentations: ['@opentelemetry/instrumentation-http'],
 });


### PR DESCRIPTION
Why:
* To distinguish between the different environments

How:
* Adding the `NEXT_APP_SIGNAL_ENV` env var
