### PR TITLE
Update Sale and test mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Audit reports
 
 - [2022-05-04 - Hacken - Token Sale contracts](./audits/2022-05-04_hacken_token-sale.pdf)
+- [2024-05-18 - Cure53 - Sale contracts](./audits/FRC-03-report.pdf)
 
 ## Development
 

--- a/packages/contracts/contracts/token/Sale.sol
+++ b/packages/contracts/contracts/token/Sale.sol
@@ -457,6 +457,7 @@ contract Sale is ISale, RisingTide, ERC165, AccessControl, ReentrancyGuard {
     function setMinContribution(
         uint256 _minContribution
     ) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
+        require(_minContribution > 0, "can't be zero");
         minContribution = _minContribution;
     }
 

--- a/packages/contracts/script/DevDeploy.s.sol
+++ b/packages/contracts/script/DevDeploy.s.sol
@@ -41,7 +41,7 @@ contract DevDeployScript is Script {
         start = 1715947200;
         end = 1716033600;
 
-        MockERC20 paymentToken = new MockERC20("USDC", "USDC", 18);
+        MockERC20 paymentToken = new MockERC20("USDC", "USDC", 6);
         Sale sale = new Sale(
             address(paymentToken),
             0.2 ether,

--- a/packages/contracts/test/contracts/token/Sale.d.sol
+++ b/packages/contracts/test/contracts/token/Sale.d.sol
@@ -56,7 +56,7 @@ contract SaleTest is Test {
             0x070e8db97b197cc0e4a1790c5e6c3667bab32d733db7f815fbe84f5824c7168d
         );
 
-        paymentToken = new MockERC20("USDC", "USDC", 18);
+        paymentToken = new MockERC20("USDC", "USDC", 6);
         token = new Citizend(owner, end);
         sale = new Sale(
             address(paymentToken),


### PR DESCRIPTION
Why:
* The audit reported an issue with the `minContribution` value
* The USDC contract only uses 6 decimals

How:
* Adding a require to prevent setting the `minContribution` to 0
* Updating the test mock and dev deploy script to use 6 decimals for the
  ERC20 mock contract
